### PR TITLE
Handle heading spaces on message field

### DIFF
--- a/lib/fluent/plugin/parser_cri.rb
+++ b/lib/fluent/plugin/parser_cri.rb
@@ -40,7 +40,7 @@ module Fluent
       end
 
       def parse(text)
-        elems = text.split(" ".freeze, 4)
+        elems = text.split(/\s/.freeze, 4)
         return yield nil if elems.size != 4
 
         if @sub_parser

--- a/test/plugin/test_parser_cri.rb
+++ b/test/plugin/test_parser_cri.rb
@@ -27,7 +27,7 @@ class CriParserTest < Test::Unit::TestCase
     end
   end
 
-  def test_parse_with_heading_spaces
+  def test_parse_with_keeping_heading_spaces
     d = create_driver('')
     log = '2020-10-10T00:10:00.333333333Z stdout F    Hello Fluentd with heading spaces'
     d.instance.parse(log) do |time, record|

--- a/test/plugin/test_parser_cri.rb
+++ b/test/plugin/test_parser_cri.rb
@@ -27,6 +27,17 @@ class CriParserTest < Test::Unit::TestCase
     end
   end
 
+  def test_parse_with_heading_spaces
+    d = create_driver('')
+    log = '2020-10-10T00:10:00.333333333Z stdout F    Hello Fluentd with heading spaces'
+    d.instance.parse(log) do |time, record|
+      t = event_time('2020-10-10T00:10:00.333333333Z', format: '%Y-%m-%dT%H:%M:%S.%L%z')
+      r = {'stream' => 'stdout', 'logtag' => 'F', 'message' => '   Hello Fluentd with heading spaces', 'time' => '2020-10-10T00:10:00.333333333Z'}
+      assert_equal t, time
+      assert_equal r, record
+    end
+  end
+
   def test_parse_without_keep_time_key
     conf = %[keep_time_key false]
     d = create_driver(conf)


### PR DESCRIPTION
Sometimes heading spaces on message field appeared on CRI-O format logs.
We should handle it properly.

When using " " as a separator on String#split, heading spaces will be removed.
For this circumstances, we should specify one space regex (`\s`) on String#split. 

Closes #1

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>