### PR TITLE
CI: Add Ruby 3.3 / 3.4 and remove unnecessary installation

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '3.2', '3.1', '3.0', '2.7' ]
+        ruby: [ '3.4', '3.3', '3.2', '3.1', '3.0', '2.7' ]
         os:
           - ubuntu-latest
     name: Ruby ${{ matrix.ruby }} unit testing on ${{ matrix.os }}
@@ -23,6 +23,5 @@ jobs:
       env:
         CI: true
       run: |
-        gem install bundler rake
         bundle install --jobs 4 --retry 3
         bundle exec rake test

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 /test/version_tmp/
 /tmp/
 
+Gemfile.lock
+
 # Used by dotenv library to load environment variables.
 # .env
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
 source "https://rubygems.org"
 
 gemspec
+
+gem "bundler"
+gem "rake"
+gem "test-unit", "~> 3.3"

--- a/fluent-plugin-parser-cri.gemspec
+++ b/fluent-plugin-parser-cri.gemspec
@@ -20,8 +20,5 @@ Gem::Specification.new do |spec|
   spec.test_files    = test_files
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 2.1"
-  spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "test-unit", "~> 3.3"
   spec.add_runtime_dependency "fluentd", ">= 1"
 end


### PR DESCRIPTION
This PR will fix CI failure in Ruby 2.7.
Ref. https://github.com/fluent/fluent-plugin-parser-cri/pull/16